### PR TITLE
Login Screen Updated

### DIFF
--- a/app/src/main/java/com/jesse/ohunelo/presentation/ui/fragment/authentication/LoginFragment.kt
+++ b/app/src/main/java/com/jesse/ohunelo/presentation/ui/fragment/authentication/LoginFragment.kt
@@ -49,8 +49,6 @@ class LoginFragment : Fragment() {
 
         setOnClickListeners()
 
-        setOnTextChangedListeners()
-
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED){
                 viewModel.loginUiStateFlow.collect{
@@ -77,6 +75,10 @@ class LoginFragment : Fragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        setOnTextChangedListeners()
+    }
     private fun setOnClickListeners() {
         binding.loginButton.setOnClickListener {
             viewModel.login()


### PR DESCRIPTION
- Login screen validation was added
- When we first launch the app and get to the login screen the text fields show no error. When we then move to forgot password from the login screen and then go back to the login screen, the text fields show an error. This is not what i want, so i decided to call the setOnTextChangedListener function from the onResume callback of the fragment to get the necessary behavior.