### PR TITLE
login form validation modified

### DIFF
--- a/app/src/main/java/com/jesse/ohunelo/di/AppModule.kt
+++ b/app/src/main/java/com/jesse/ohunelo/di/AppModule.kt
@@ -4,6 +4,8 @@ import com.jesse.ohunelo.data.repository.RecipeRepository
 import com.jesse.ohunelo.data.repository.RecipeRepositoryImpl
 import com.jesse.ohunelo.domain.usecase.ValidateEmailUseCase
 import com.jesse.ohunelo.domain.usecase.ValidatePasswordUseCase
+import com.jesse.ohunelo.util.EmailMatcher
+import com.jesse.ohunelo.util.EmailMatcherImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,6 +24,10 @@ object AppModule {
     fun providesRecipeRepository(recipeRepositoryImpl: RecipeRepositoryImpl): RecipeRepository =
         recipeRepositoryImpl
 
+    @Provides
+    @Singleton
+    fun providesEmailMatcher(emailMatcherImpl: EmailMatcherImpl): EmailMatcher = emailMatcherImpl
+
     @IODispatcher
     @Provides
     fun provideIODispatcher(): CoroutineDispatcher = Dispatchers.IO
@@ -31,7 +37,8 @@ object AppModule {
     fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
     @Provides
-    fun provideValidateEmailUseCase(): ValidateEmailUseCase = ValidateEmailUseCase()
+    fun provideValidateEmailUseCase(emailMatcher: EmailMatcher):
+            ValidateEmailUseCase = ValidateEmailUseCase(emailMatcher)
 
     @Provides
     fun provideValidatePasswordUseCase(): ValidatePasswordUseCase = ValidatePasswordUseCase()

--- a/app/src/main/java/com/jesse/ohunelo/domain/usecase/ValidateEmailUseCase.kt
+++ b/app/src/main/java/com/jesse/ohunelo/domain/usecase/ValidateEmailUseCase.kt
@@ -1,10 +1,14 @@
 package com.jesse.ohunelo.domain.usecase
 
+import android.util.Patterns
 import com.jesse.ohunelo.R
+import com.jesse.ohunelo.util.EmailMatcher
 import com.jesse.ohunelo.util.UiText
 import javax.inject.Inject
 
-class ValidateEmailUseCase @Inject constructor() {
+class ValidateEmailUseCase @Inject constructor(
+    private val emailMatcher: EmailMatcher
+) {
 
     operator fun invoke(email: String): ValidationResult{
 
@@ -14,7 +18,7 @@ class ValidateEmailUseCase @Inject constructor() {
                 errorMessage = UiText.StringResource(R.string.this_field_cannot_be_blank)
             )
         }
-        if(!isEmailPatterValid(email)){
+        if(!emailMatcher.emailMatches(email)){
             return ValidationResult(
                 successful = false,
                 errorMessage = UiText.StringResource(R.string.invalid_email)
@@ -23,18 +27,5 @@ class ValidateEmailUseCase @Inject constructor() {
         return ValidationResult(successful = true)
     }
 
-    private fun isEmailPatterValid(email: String): Boolean{
-        /*
-        * The regular expression pattern ^\\w+([.-]?\\w+)*@\\w+([.-]?\\w+)*(\\.\\w{2,4})+$ checks for the following conditions:
-        It starts with one or more word characters (\\w+).
-        It allows for zero or more groups of characters separated by a dot ([.-]?\\w+), such as . or -username.
-        It requires the @ symbol.
-        It allows for one or more word characters after the @ symbol (\\w+).
-        It allows for zero or more groups of characters separated by a dot ([.-]?\\w+), such as .com or .co.uk.
-        It ensures that the top-level domain has between 2 to 4 characters (\\.\\w{2,4}).
-        It uses the ^ and $ anchors to match the entire string.
-        * */
-        val regexPattern = Regex("^\\w+([.-]?\\w+)*@\\w+([.-]?\\w+)*(\\.\\w{2,4})+$")
-        return regexPattern.matches(email)
-    }
+
 }

--- a/app/src/main/java/com/jesse/ohunelo/domain/usecase/ValidatePasswordUseCase.kt
+++ b/app/src/main/java/com/jesse/ohunelo/domain/usecase/ValidatePasswordUseCase.kt
@@ -6,14 +6,14 @@ import javax.inject.Inject
 
 class ValidatePasswordUseCase @Inject constructor(){
 
-    operator fun invoke(password: String): ValidationResult{
+    operator fun invoke(password: String, shouldValidatePasswordPattern: Boolean): ValidationResult{
         if (password.isBlank()){
             return ValidationResult(
                 successful = false,
                 errorMessage = UiText.StringResource(R.string.this_field_cannot_be_blank)
             )
         }
-        if(!isPasswordPatterValid(password)){
+        if(!isPasswordPatterValid(password) && shouldValidatePasswordPattern){
             return ValidationResult(
                 successful = false,
                 errorMessage = UiText.StringResource(R.string.password_must_contain)

--- a/app/src/main/java/com/jesse/ohunelo/domain/usecase/ValidateUsernameUseCase.kt
+++ b/app/src/main/java/com/jesse/ohunelo/domain/usecase/ValidateUsernameUseCase.kt
@@ -1,0 +1,37 @@
+package com.jesse.ohunelo.domain.usecase
+
+import com.jesse.ohunelo.R
+import com.jesse.ohunelo.util.UiText
+import javax.inject.Inject
+
+class ValidateUsernameUseCase @Inject constructor(){
+
+    operator fun invoke(username: String): ValidationResult{
+        if (username.isBlank()){
+            return ValidationResult(
+                successful = false,
+                errorMessage = UiText.StringResource(R.string.this_field_cannot_be_blank)
+            )
+        }
+        if (!isUsernamePatternValid(username)){
+            return ValidationResult(
+                successful = false,
+                errorMessage = UiText.StringResource(R.string.this_field_cannot_be_blank)
+            )
+        }
+        return ValidationResult(successful = true)
+    }
+
+    private fun isUsernamePatternValid(username: String): Boolean {
+        /*
+        * The regular expression pattern ^(?=\\S{8,16}$)(?!.*\\s{2,}).*\\S$ checks for the following conditions:
+        ^: Start of the string.
+        (?=\\S{8,16}$): Positive lookahead assertion to ensure the string has 8 to 16 non-whitespace characters.
+        (?!.*\\s{2,}): Negative lookahead assertion to prevent more than one consecutive blank space.
+        .*\\S: Match any character (except whitespace) at least once.
+        $: End of the string.
+        * */
+        val regexPattern = Regex("^(?=\\S{8,16}$)(?!.*\\s{2,}).*\\S$")
+        return regexPattern.matches(username)
+    }
+}

--- a/app/src/main/java/com/jesse/ohunelo/presentation/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/com/jesse/ohunelo/presentation/viewmodels/LoginViewModel.kt
@@ -1,13 +1,18 @@
 package com.jesse.ohunelo.presentation.viewmodels
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.jesse.ohunelo.domain.usecase.ValidateEmailUseCase
 import com.jesse.ohunelo.domain.usecase.ValidatePasswordUseCase
 import com.jesse.ohunelo.presentation.uistates.LoginUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -17,27 +22,44 @@ class LoginViewModel @Inject constructor(
 ): ViewModel() {
 
     private val _loginUiStateFlow: MutableStateFlow<LoginUiState> = MutableStateFlow(LoginUiState())
-    val loginUiStateFlow get() = _loginUiStateFlow.asStateFlow()
+    val loginUiStateFlow: StateFlow<LoginUiState> get() = _loginUiStateFlow.asStateFlow()
+
+    // This is to ensure that validation of text in EditText is optimal. When user enters text,
+    // validation doesn't happen immediately, initial task is canceled and restarted then there is
+    // a delay of 500 milliseconds (to ensure that user has finished typing or not) before validation
+    // actually occurs and UI state is updated.
+    private var validationJob: Job? = null
+
+    private val delayTime = 500L
 
     fun onEmailTextChanged(emailText: String){
-        _loginUiStateFlow.update {
-            loginUiState ->
-            val emailValidation = validateEmailUseCase(emailText)
-            loginUiState.copy(
-                email = emailText,
-                emailError = emailValidation.errorMessage
-            )
+        validationJob?.cancel()
+        validationJob = viewModelScope.launch {
+            delay(delayTime)
+            _loginUiStateFlow.update {
+                    loginUiState ->
+                val emailValidation = validateEmailUseCase(emailText)
+                loginUiState.copy(
+                    email = emailText,
+                    emailError = emailValidation.errorMessage
+                )
+            }
         }
     }
 
     fun onPasswordTextChanged(passwordText: String){
-        _loginUiStateFlow.update {
-            loginUiState ->
-            val passwordValidation = validatePasswordUseCase(passwordText)
-            loginUiState.copy(
-                password = passwordText,
-                passwordError = passwordValidation.errorMessage
-            )
+        validationJob?.cancel()
+        validationJob = viewModelScope.launch {
+            delay(delayTime)
+            _loginUiStateFlow.update {
+                    loginUiState ->
+                val passwordValidation = validatePasswordUseCase(password = passwordText,
+                    shouldValidatePasswordPattern = false)
+                loginUiState.copy(
+                    password = passwordText,
+                    passwordError = passwordValidation.errorMessage
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/jesse/ohunelo/util/EmailMatcher.kt
+++ b/app/src/main/java/com/jesse/ohunelo/util/EmailMatcher.kt
@@ -1,0 +1,16 @@
+package com.jesse.ohunelo.util
+
+import android.util.Patterns
+import javax.inject.Inject
+
+/** This was done to abstract the android.util.Patterns keeping the ValidateEmailUseCase
+ testable.**/
+interface EmailMatcher{
+    fun emailMatches(email: String): Boolean
+}
+
+class EmailMatcherImpl @Inject constructor(): EmailMatcher{
+    override fun emailMatches(email: String): Boolean {
+        return Patterns.EMAIL_ADDRESS.matcher(email).matches()
+    }
+}

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -119,6 +119,7 @@
                     app:hintEnabled="false"
                     app:errorEnabled="true"
                     android:textColorHint="@color/orange_100"
+                    app:errorIconDrawable="@null"
                     app:errorMessageText="@{viewModel.loginUiStateFlow.passwordError}"
                     style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                     >


### PR DESCRIPTION
Login Form Validation was modified
- ValidateEmailUseCase now uses android's patterns util email address matcher to validate email.
- The android's patterns util email address matcher was abstracted for unit tests sake.
- debounce logic was added to LoginViewModel for validation of email and password.
- ValidatePasswordUseCase invoke function now takes a shouldValidatePasswordPattern parameter to know whether or not password pattern should also be validated based on where it was called from.
- Error icon for password TextInputLayout was disabled