### PR TITLE
Recipe Details API Plugin Ongoing

### DIFF
--- a/app/src/main/java/com/jesse/ohunelo/data/network/ApiKeyInterceptor.kt
+++ b/app/src/main/java/com/jesse/ohunelo/data/network/ApiKeyInterceptor.kt
@@ -1,0 +1,20 @@
+package com.jesse.ohunelo.data.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class ApiKeyInterceptor(private val apiKey: String): Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val newUrl = originalRequest.url.newBuilder()
+            .addQueryParameter("apiKey", apiKey)
+            .build()
+
+        val newRequest = originalRequest.newBuilder()
+            .url(newUrl)
+            .build()
+
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/jesse/ohunelo/data/network/SpoonacularService.kt
+++ b/app/src/main/java/com/jesse/ohunelo/data/network/SpoonacularService.kt
@@ -1,19 +1,14 @@
 package com.jesse.ohunelo.data.network
 
-import com.jesse.ohunelo.BuildConfig
-import com.jesse.ohunelo.data.network.models.RecipeResponse
 import com.jesse.ohunelo.data.network.models.RecipesByMealTypeResponse
-import com.jesse.ohunelo.data.network.models.RecipesResponse
 import com.jesse.ohunelo.util.HOME_SCREEN_RECIPES_AMOUNT
 import retrofit2.http.GET
-import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface SpoonacularService {
 
     @GET("complexSearch")
     suspend fun getRecipes(
-        @Query("apiKey") apiKey: String = BuildConfig.API_KEY,
         @Query("number") number: Int = HOME_SCREEN_RECIPES_AMOUNT,
         @Query("type") mealType: String = "",
         @Query("addRecipeInformation") addRecipeInformation: Boolean = true,

--- a/app/src/main/java/com/jesse/ohunelo/di/AppModule.kt
+++ b/app/src/main/java/com/jesse/ohunelo/di/AppModule.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.room.Room
+import com.jesse.ohunelo.BuildConfig
 import com.jesse.ohunelo.data.local.RecipeLocalDataSource
 import com.jesse.ohunelo.data.local.RecipeLocalDataSourceImpl
 import com.jesse.ohunelo.data.local.database.RecipeDatabase
 import com.jesse.ohunelo.data.local.database.RecipeDatabasePassphrase
+import com.jesse.ohunelo.data.network.ApiKeyInterceptor
 import com.jesse.ohunelo.data.network.AuthenticationService
 import com.jesse.ohunelo.data.network.FirebaseAuthenticationService
 import com.jesse.ohunelo.data.network.RecipeNetworkDataSource
@@ -64,6 +66,7 @@ object AppModule {
             .writeTimeout(1, TimeUnit.MINUTES)
             .connectTimeout(1, TimeUnit.MINUTES)
             .addInterceptor(okHttpLoggingInterceptor)
+            .addInterceptor(ApiKeyInterceptor(BuildConfig.API_KEY))
             .build()
 
     @Singleton


### PR DESCRIPTION
- Recipe Details ImageView is now disabled when clicked on and renabled when dialog is dismissed.
- IngredientsViewModel was added.
- Image Sizing for ingredient item was changed.
- ApiKeyInterceptor was added, so when api calls are made the apikey is appended to the url before finalizing the call. There is no longer a need to manually to apikey as a query parameter to our SpoonacularService methods.